### PR TITLE
Update version to 2016-06-26a

### DIFF
--- a/.openshift/action_hooks/build
+++ b/.openshift/action_hooks/build
@@ -4,7 +4,7 @@
 # before the deploy step.  This script gets executed directly, so it
 # could be python, php, ruby, etc.
 
-install_version="release_stable_2015-08-10a"
+install_version="release_stable_2016-06-26a"
 
 download_url="https://codeload.github.com/splitbrain/dokuwiki/tar.gz/${install_version}"
 


### PR DESCRIPTION
Hi guys,
I am not very clear how to update my wiki on OpenShift. I pushed this change to the server and get output:
> Counting objects: 5, done.
> Delta compression using up to 8 threads.
> Compressing objects: 100% (5/5), done.
> Writing objects: 100% (5/5), 583 bytes | 0 bytes/s, done.
> Total 5 (delta 2), reused 0 (delta 0)
> remote: Stopping PHP 5.4 cartridge (Apache+mod_php)
> remote: Waiting for stop to finish
> remote: Waiting for stop to finish
> remote: Building git ref 'master', commit 89a984a
> remote: Preparing build for deployment
> remote: Deployment id is 7caefbfb
> remote: Activating deployment
> remote: Starting PHP 5.4 cartridge (Apache+mod_php)
> remote: Application directory "php/" selected as DocumentRoot
> remote: -------------------------
> remote: Git Post-Receive Result: success
> remote: Activation status: success
> remote: Deployment completed with status: success

But wiki still show message [1] in  admin console.
[1]
> Hotfix release available fixing authad issues: 2016-06-26a "Elenor of Tsort". 

What should I do to update my wiki?